### PR TITLE
[Tetris #4] Implement vcpkg to install dependencies: SDL2 & SDL2-ttf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 build/
+CMakeUserPresets.json
+out/
+.vscode/
+.vs/
+vcpkg_installed/

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,18 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 10,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "vcpkg",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+      }
+    }
+  ]
+}

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,14 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "baseline": "4f8fe05871555c1798dbcb1957d0d595e94f7b57",
+    "repository": "https://github.com/microsoft/vcpkg"
+  },
+  "registries": [
+    {
+      "kind": "artifact",
+      "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+      "name": "microsoft"
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": [
+    "sdl2",
+    "sdl2-ttf"
+  ]
+}


### PR DESCRIPTION
Incorporated a basic implementation of vcpkg to install the project's current dependencies: SDL2 & SDL2-ttf

Running `vcpkg install` in the project's source directory will allow the use of SDL2 dependencies.