### PR TITLE
[Tetris #31] Implemented Catch2 with CMake and vcpkg, started writing tests for Flat2DArray

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,11 @@
+# Cmake configuration
 cmake_minimum_required(VERSION 3.20)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# Project details
 project(
 	Tetris
 	VERSION 1.0
@@ -11,8 +13,12 @@ project(
 	LANGUAGES CXX
 )
 
+# Subdirectories
 add_subdirectory(src/core)
-add_subdirectory(src/app)
-
-# NOTE: The render module is not yet ready for implementation.
+# NOTE: The render and app modules are not yet ready for implementation.
+# add_subdirectory(src/app)
 # add_subdirectory(src/render)
+
+# Tests
+add_subdirectory(tests/core)
+# add_subdirectory(tests/app)

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -1,0 +1,16 @@
+enable_testing()
+
+find_package(Catch2 CONFIG REQUIRED) 
+
+include_directories(${PROJECT_SOURCE_DIR}/src/core/include)
+
+set(CORE_TEST_SOURCES
+  testFlat2DArray.cpp
+)
+
+add_executable(core_tests ${CORE_TEST_SOURCES})
+target_link_libraries(core_tests Catch2::Catch2WithMain) 
+
+include(CTest)
+include(Catch)
+catch_discover_tests(core_tests)

--- a/tests/core/testFlat2DArray.cpp
+++ b/tests/core/testFlat2DArray.cpp
@@ -1,0 +1,10 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch_test_macros.hpp>
+
+#include "Flat2DArray.hpp"
+
+TEST_CASE("Flat2DArray implementation test", "[unit]")
+{
+  Flat2DArray<int, 2, 2> arr;
+  REQUIRE(arr.size() == 4);
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "dependencies": [
     "sdl2",
-    "sdl2-ttf"
+    "sdl2-ttf",
+    "catch2"
   ]
 }


### PR DESCRIPTION
[Tetris #31] Implemented Catch2 with CMake and vcpkg, started writing tests for Flat2DArray
Catch2 can now be automatically installed with vcpkg when running cmake. Unit tests will be written for Flat2DArray